### PR TITLE
Add scripts to facilitate legacy baking

### DIFF
--- a/bake_legacy
+++ b/bake_legacy
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+usage="bake -r <legacy_recipe_file> -i <inputfile> -o <outputfile>"
+
+# Get command line arguments
+
+while getopts i:o:r:h flag
+do
+  case "${flag}" in
+    i) input_file=${OPTARG} ;;
+    o) output_file=${OPTARG} ;;
+    r) legacy_recipe_file=${OPTARG} ;;
+    h) echo "$usage"; exit 0 ;;
+    *) echo "Unknown flag '${flag}'"; exit 1 ;;
+  esac
+done
+
+cnx-easybake -q "$legacy_recipe_file" "$input_file" "$output_file"

--- a/bake_root
+++ b/bake_root
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+usage="bake -b <bookname> -r <legacy_recipes_dir> -i <inputfile> -o <outputfile>"
+
+# Get command line arguments
+
+while getopts b:i:o:r:h flag
+do
+  case "${flag}" in
+    b) book=${OPTARG} ;;
+    i) input_file=${OPTARG} ;;
+    o) output_file=${OPTARG} ;;
+    r) legacy_recipes_dir=${OPTARG} ;;
+    h) echo "$usage"; exit 0 ;;
+    *) echo "Unknown flag '${flag}'"; exit 1 ;;
+  esac
+done
+
+# Known supported books will use the kitchen baking, all others will fallback
+# to legacy.
+
+case "${book}" in
+  chemistry2e)
+    echo "Baking book '${book}' with kitchen" ;
+    "${DIR}/bake" -b "$book" -i "$input_file" -o "$output_file";;
+  *) echo "Baking book '${book}' with legacy baking";
+    "${DIR}/bake_legacy" -i "$input_file" -o "$output_file" -r "${legacy_recipes_dir}/${book}.css";;
+esac


### PR DESCRIPTION
This change adds a couple of scripts that allow users / pipelines to
build books with either kitchen or legacy cnx-easybake depending upon
support in the former for a given book.