### PR TITLE
add devcontainer, rubocop, lefthook

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+  "name": "Recipes Dev",
+  "build": {
+    "dockerfile": "../docker/Dockerfile",
+    "context": "..",
+    "target": "dev-env",
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/code,type=bind,consistency=default",
+  "workspaceFolder": "/code",
+  "extensions": [
+    "castwide.solargraph",
+    "rebornix.Ruby",
+    "MS-vsliveshare.vsliveshare-pack"
+  ],
+  "settings": {
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "[ruby]": {
+      "editor.insertSpaces": true,
+      "editor.tabSize": 2,
+    },
+    "ruby.lint": {
+      "rubocop": {
+        "useBundler": false, // enable rubocop via bundler
+      },
+    },
+    "ruby.format": "rubocop", // use rubocop for formatting
+    "ruby.useLanguageServer": true,
+    "solargraph.commandPath": "/usr/local/bundle/bin/solargraph",
+    "solargraph.bundlerPath": "/usr/local/bin/bundle",
+    "ruby.rubocop.executePath": "/usr/local/bundle/bin/",
+    "ruby.rubocop.onSave": true,
+    "ruby.rubocop.configFilePath": "/code/.rubocop.yml",
+    "terminal.integrated.scrollback": 100000
+  }
+}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,57 @@
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 100
+
+Metrics/AbcSize:
+  Max: 50
+
+Naming/PredicateName:
+  Enabled: false
+
+Metrics/ClassLength:
+  Max: 300
+  CountAsOne: ['heredoc']
+
+Metrics/MethodLength:
+  Max: 50
+  CountAsOne: ['heredoc']
+
+# Recipes have long blocks on purpose
+Metrics/BlockLength:
+  Enabled: false
+  CountAsOne: ['heredoc']
+
+Metrics/ModuleLength:
+  CountAsOne: ['heredoc']
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+Style/StringLiterals:
+  ConsistentQuotesInMultiline: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Style/AccessorGrouping:
+  EnforcedStyle: separated
+
+Style/SingleLineMethods:
+  Enabled: false # don't abuse it, but sometimes it is right
+
+Style/RegexpLiteral:
+  AllowInnerSlashes: true
+
+Style/SymbolProc:
+  IgnoredMethods:
+    - respond_to
+    - define_method
+    - XML # For Nokogiri::XML
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false # when true hanging parens look weird

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ To build the docker image:
 $> ./docker/build
 ```
 
+Note this builds the runtime environment, suitable for running in production and some development work.  If you want a more full development environment, use VS Code using the remote containers extension.  This will build the development environment with a nice terminal, VS Code Live Share for pairing, etc.  To install the remote containers extension, visit `vscode:extension/ms-vscode-remote.remote-containers` in a browser.
+
 This image includes all of the versions of gems used in each recipe so that they are available when used to bake files.  Notably, if you change the version of a gem in one of the executable recipes, you'll need to either rebuild the Docker image or call the `./scripts/install_used_gem_versions` script which scans through all of the recipes, installing the gem versions they specify in their inline gem file declarations.
 
 To drop into the Docker container:
@@ -111,3 +113,7 @@ If you want to bake a book with legacy baking which `bake_root` would otherwise 
     openstax/recipes:latest \
     /code/bake_legacy -i /files/input.xhtml -r /recipes/chemistry.css -o /files/baked.xhtml  # Invoke the `bake_legacy` script
 ```
+
+## Rubocop
+
+Rubocop is available inside the VSCode dev container.  Moreover, the `lefthook` gem enforces that Rubocop linting passes on modified files before pushes are allowed.  To test this without pushing run `lefthook run pre-push`.

--- a/books/chemistry2e/bake
+++ b/books/chemistry2e/bake
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
-require "bundler/inline"
+# frozen_string_literal: true
+
+require 'bundler/inline'
 
 gemfile do
   gem 'openstax_kitchen', '2.0.0'
@@ -8,22 +10,22 @@ gemfile do
   gem 'byebug'
 end
 
-include Kitchen::Directions
-
 recipe = Kitchen::BookRecipe.new(book_short_name: :chemistry) do |doc|
+  include Kitchen::Directions
+
   book = doc.book
 
   # Some stuff just goes away
-  book.search("cnx-pi").trash
+  book.search('cnx-pi').trash
 
-  # Update the preface title
-  book.pages("$.preface").search("div[data-type='document-title']").each do |title| # TODO add title method
+  # Update the preface title  TODO: add title method
+  book.pages('$.preface').search("div[data-type='document-title']").each do |title|
     title.replace_children(with:
       <<~HTML
         <span data-type="" itemprop="" class="os-text">#{title.text}</span>
       HTML
     )
-    title.name = "h1"
+    title.name = 'h1'
   end
 
   book.chapters.each do |chapter|
@@ -37,7 +39,7 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :chemistry) do |doc|
 
   book.chapters.each do |chapter|
     # Fix up chapter titles - TODO put this in BakeChapter
-    heading = chapter.at("h1[2]")
+    heading = chapter.at('h1[2]')
     heading[:id] = "chapTitle#{chapter.count_in(:book)}"
     heading.replace_children(with:
       <<~HTML
@@ -48,22 +50,23 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :chemistry) do |doc|
       HTML
     )
 
-    chapter.tables("$:not(.unnumbered)").each do |table|
-      BakeNumberedTable.v1(table: table, number: "#{chapter.count_in(:book)}.#{table.count_in(:chapter)}")
+    chapter.tables('$:not(.unnumbered)').each do |table|
+      BakeNumberedTable.v1(table: table,
+                           number: "#{chapter.count_in(:book)}.#{table.count_in(:chapter)}")
     end
 
     chapter.examples.each do |example|
       BakeExample.v1(example: example,
                      number: "#{chapter.count_in(:book)}.#{example.count_in(:chapter)}",
-                     title_tag: "h3")
+                     title_tag: 'h3')
     end
 
-    chapter.pages("$:not(.introduction)").each do |page|
+    chapter.pages('$:not(.introduction)').each do |page|
       page.search("div[data-type='description']").each(&:trash)
-      page.add_class("chapter-content-module")
+      page.add_class('chapter-content-module')
 
       title = page.search("div[data-type='document-title']").first
-      title.name = "h2"
+      title.name = 'h2'
       title.replace_children(with:
         <<~HTML
           <span class="os-number">#{chapter.count_in(:book)}.#{page.count_in(:chapter)}</span>
@@ -74,25 +77,26 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :chemistry) do |doc|
     end
 
     chapter.figures.each do |figure|
-      BakeFigure.v1(figure: figure, number: "#{chapter.count_in(:book)}.#{figure.count_in(:chapter)}")
+      BakeFigure.v1(figure: figure,
+                    number: "#{chapter.count_in(:book)}.#{figure.count_in(:chapter)}")
     end
   end
 
-  book.pages("$.appendix").each do |page|
-    appendix_letter = [*('A'..'Z')][page.count_in(:book)-1]
+  book.pages('$.appendix').each do |page|
+    appendix_letter = [*('A'..'Z')][page.count_in(:book) - 1]
 
     page.figures.each do |figure|
       BakeFigure.v1(figure: figure, number: "#{appendix_letter}#{figure.count_in(:page)}")
     end
 
-    page.tables("$:not(.unnumbered)").each do |table|
+    page.tables('$:not(.unnumbered)').each do |table|
       BakeNumberedTable.v1(table: table, number: "#{appendix_letter}#{table.count_in(:page)}")
     end
 
     page.examples.each do |example|
       BakeExample.v1(example: example,
                      number: "#{appendix_letter}#{example.count_in(:page)}",
-                     title_tag: "div")
+                     title_tag: 'div')
     end
 
     BakeAppendix.v1(page: page, number: appendix_letter)
@@ -109,14 +113,15 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :chemistry) do |doc|
   BakeToc.v1(book: book)
 
   # competing docs from elements - BakeLinkPlaceholders
-  book.search("a").each do |anchor|
-    next unless anchor.text == "[link]"
+  book.search('a').each do |anchor|
+    next unless anchor.text == '[link]'
+
     id = anchor[:href][1..-1]
     replacement = doc.pantry(name: :link_text).get(id)
     if replacement.present?
       anchor.replace_children(with: replacement)
     else
-      # TODO log a warning!
+      # TODO: log a warning!
       puts "warning! could not find a replacement for '[link]' on an element with ID '#{id}'"
     end
   end

--- a/books/chemistry2e/bake
+++ b/books/chemistry2e/bake
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-# frozen_string_literal: true
-
 require 'bundler/inline'
 
 gemfile do

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-buster
+FROM ruby:2.6.6-buster AS runtime-env
 
 ARG EASYBAKE_VERSION=1.2.7
 # Install bundler and all the versions of gems we need. Notes:
@@ -34,3 +34,31 @@ RUN pip install cnx-easybake==${EASYBAKE_VERSION}
 # Install gems which are needed to run each recipe
 COPY . /code
 RUN /code/scripts/install_used_gem_versions
+WORKDIR /code
+
+# The following dev-env stage is mostly useful for devcontainer runs in VSCode
+
+FROM runtime-env AS dev-env
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    vim \
+    openssh-server \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install a quick colorized prompt and turn on ls coloring
+RUN git clone https://github.com/nojhan/liquidprompt.git ~/liquidprompt && \
+    echo '[[ $- = *i* ]] && source ~/liquidprompt/liquidprompt' >>~/.bashrc && \
+    mkdir -p ~/.config && \
+    echo 'export LP_HOSTNAME_ALWAYS=1' >>~/.config/liquidpromptrc && \
+    echo 'export LP_USER_ALWAYS=-1' >>~/.config/liquidpromptrc && \
+    sed -i "/color=auto/"' s/# //' ~/.bashrc && \
+    sed -i "/alias ls/,/lA/"' s/# //' ~/.bashrc
+
+# VSCode Live Share libraries
+RUN wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && chmod +x ~/vsls-reqs && ~/vsls-reqs
+
+RUN gem install solargraph && \
+    gem install lefthook && \
+    gem install rubocop

--- a/docker/build
+++ b/docker/build
@@ -4,4 +4,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 docker build -f $DIR/Dockerfile \
              -t openstax/recipes:latest \
+             --target runtime-env \
              $DIR/..

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+pre-push:
+  commands:
+    rubocop:
+      files: git diff --name-only main
+      glob: "**/{bake,console,normalize}"
+      run: rubocop {files} --disable-pending-cops


### PR DESCRIPTION
* Adds a VSCode devcontainer configuration (see README)
* Splits the Dockerfile into two stages.  The first is the runtime environment, the second is for the development environment (normally through VSCode).  The build script (`docker/build`) builds only the first stage.  The VSCode devcontainer configuration builds through the development environment stage.
* Adds lefthook for pre-push Ruby linting (see README).