### PR TITLE
Replace chemistry in bake_root with dummy

### DIFF
--- a/bake
+++ b/bake
@@ -24,5 +24,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 case "${book}" in
   chemistry) $DIR/books/chemistry/bake --input $input_file --output $output_file;;
+  dummy) $DIR/books/dummy/bake --input $input_file --output $output_file;;
   *) echo "Unknown book '${book}'"; exit 1;;
 esac

--- a/bake_root
+++ b/bake_root
@@ -21,8 +21,13 @@ done
 # Known supported books will use the kitchen baking, all others will fallback
 # to legacy.
 
+# NOTE: The dummy recipe is a temporary placeholder until there's a recipe that
+#       is ready for release. At that point, the case statement can be updated
+#       accordingly and the dummy recipe removed altogether both here and in
+#       the underlying bake script.
+
 case "${book}" in
-  chemistry)
+  dummy)
     echo "Baking book '${book}' with kitchen" ;
     "${DIR}/bake" -b "$book" -i "$input_file" -o "$output_file";;
   *) echo "Baking book '${book}' with legacy baking";

--- a/books/dummy/bake
+++ b/books/dummy/bake
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'bundler/inline'
+
+gemfile do
+  gem 'openstax_kitchen', '2.0.0'
+  gem 'slop', '4.8.2'
+end
+
+opts = Slop.parse do |slop|
+  slop.string '--input', 'Assembled XHTML input file', required: true
+  slop.string '--output', 'Baked XHTML output file', required: true
+end
+
+puts Kitchen::Oven.bake(
+  input_file: opts[:input],
+  recipes: [],
+  output_file: opts[:output]
+)


### PR DESCRIPTION
This is to revert the behavior whereby `bake_root` invokes kitchen
for chemistry. Instead, until a recipe is ready to go out, for basic
testing of the switching logic we'll support the dummy recipe in the
root script.