### PR TITLE
Update cnx-easybake from 1.2.7 to 1.2.8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.6-buster AS runtime-env
 
-ARG EASYBAKE_VERSION=1.2.7
+ARG EASYBAKE_VERSION=1.2.8
 # Install bundler and all the versions of gems we need. Notes:
 #
 # 1) Git is required for bundler since we may sometimes have a


### PR DESCRIPTION
This is to incorporate the pinning of lxml version in the Docker
image used for baking.