### PR TITLE
remove intro business from bake root file

### DIFF
--- a/bake_root
+++ b/bake_root
@@ -28,6 +28,9 @@ done
 
 case "${book}" in
   # Please add newly finished books to the case statement in ALPHABETICAL ORDER!
+
+  # Note: Add intro-business when content problem be fixed https://github.com/openstax/recipes/issues/158
+
   additive-manufacturing | \
   american-government | \
   anatomy | \
@@ -45,7 +48,6 @@ case "${book}" in
   english-composition | \
   finance | \
   hs-physics | \
-  intro-business | \
   microbiology | \
   philosophy | \
   pl-psychology | \


### PR DESCRIPTION
Intro Business can't be tested because of content problem, so decision is to remove this book from the `book_root` file for now.

Here is a discusion: https://katalysteducation.slack.com/archives/C022NETP39N/p1637596308478900?thread_ts=1637588594.472600&cid=C022NETP39N