### PR TITLE
remove accounting bake root

### DIFF
--- a/bake_root
+++ b/bake_root
@@ -31,7 +31,6 @@ case "${book}" in
 
   # Note: Add intro-business when content problem be fixed https://github.com/openstax/recipes/issues/158
 
-  accounting | \
   additive-manufacturing | \
   american-government | \
   anatomy | \


### PR DESCRIPTION
Accounting needs to be temporarily removed from bake_root due to content fixes needed for volume 1.